### PR TITLE
Cm/allow local push

### DIFF
--- a/react-task-tracker/Makefile
+++ b/react-task-tracker/Makefile
@@ -14,8 +14,8 @@ endif
 # Use git to get branch name if it's not specified via environment variable
 # Branch name is not accessible via git in cloud build
 ifeq ($(BRANCH_NAME),)
-BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-ENDIF
+BRANCH_NAME=$$(git rev-parse --abbrev-ref HEAD)
+endif
 
 # Docker image tag name cannot contain hyphens but branches typically do
 IMAGE_TAG=$$(echo $(BRANCH_NAME) | sed 's:/:-:g')
@@ -35,10 +35,9 @@ deploy-dev:
 		--region=us-west4 \
 		--allow-unauthenticated
 
-
 push-docker:
-	docker tag $(WEBAPP_IMAGE_NAME) $(GCLOUD_DOCKER_NAME_PREFIX)/$(WEBAPP_IMAGE_NAME)
-	docker push $(GCLOUD_DOCKER_NAME_PREFIX)/$(WEBAPP_IMAGE_NAME)
+	docker tag $(WEBAPP_IMAGE_NAME) $(GCLOUD_DOCKER_NAME_PREFIX)/$(WEBAPP_IMAGE_NAME):$(IMAGE_TAG)
+	docker push $(GCLOUD_DOCKER_NAME_PREFIX)/$(WEBAPP_IMAGE_NAME):$(IMAGE_TAG)
 
 test:
 	# CI=true disables watch mode + prevents saving new screenshots

--- a/react-task-tracker/Makefile
+++ b/react-task-tracker/Makefile
@@ -11,6 +11,12 @@ ifeq ($(CWD),)
 CWD=/workspace/react-task-tracker
 endif
 
+# Use git to get branch name if it's not specified via environment variable
+# Branch name is not accessible via git in cloud build
+ifeq ($(BRANCH_NAME),)
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+ENDIF
+
 # Docker image tag name cannot contain hyphens but branches typically do
 IMAGE_TAG=$$(echo $(BRANCH_NAME) | sed 's:/:-:g')
 

--- a/task-tracker-backend/Makefile
+++ b/task-tracker-backend/Makefile
@@ -10,6 +10,12 @@ ifeq ($(CWD),)
 CWD=/workspace/task-tracker-backend
 endif
 
+# Use git to get branch name if it's not specified via environment variable
+# Branch name is not accessible via git in cloud build
+ifeq ($(BRANCH_NAME),)
+BRANCH_NAME=$$(git rev-parse --abbrev-ref HEAD)
+endif
+
 # Docker image tag name cannot contain hyphens but branches typically do
 IMAGE_TAG=$$(echo $(BRANCH_NAME) | sed 's:/:-:g')
 


### PR DESCRIPTION
If BRANCH_NAME isn't defined (it is defined in cloud build, but not locally), then use git to get the branch name. 

Git cannot be used to get the branch name in cloud build because of the way cloud build clones the repo, no branches are defined. 